### PR TITLE
Fix incorrect `hasAssertions` duplication

### DIFF
--- a/src/Vitest.res
+++ b/src/Vitest.res
@@ -5,9 +5,9 @@ type suite
 @module("vitest") @val
 external suite: suite = "expect"
 
-@send external hasAssertions: (suite, int) => unit = "hasAssertions"
+@send external assertions: (suite, int) => unit = "assertions"
 
-@send external hasAnyAssertions: suite => unit = "hasAssertions"
+@send external hasAssertions: suite => unit = "hasAssertions"
 
 type expected<'a>
 
@@ -427,6 +427,7 @@ external afterAllPromise: (@uncurry (unit => Promise.t<'a>), Js.Undefined.t<int>
 @inline
 let afterAllPromise = (~timeout=?, callback) =>
   afterAllPromise(callback, timeout->Js.Undefined.fromOption)
+
 module Expect = {
   @send external not: expected<'a> => expected<'a> = "not"
 


### PR DESCRIPTION
Vitest has a method `expect.assertions` which can be used to expect a
specific amount of assertions and it has a method `expect.hasAssertions`
to wait for any number of assertions (>=1).

We rename the methods to match the methods in Vitest itself so that the
documentation works. The only difference is that in the ReScript
bindings we have `suite` to double as the object `expect` since a
function and object can't share a name in ReScript.