### PR TITLE
correct "close to" float match expectation

### DIFF
--- a/src/Vitest.res
+++ b/src/Vitest.res
@@ -1051,7 +1051,7 @@ module Matchers = (
     @send external toBeNaN: expected => Config.return<'a> = "toBeNaN"
 
     @send
-    external toBeClosedTo: (expected, t, int) => Config.return<'a> = "toBeClosedTo"
+    external toBeCloseTo: (expected, t, int) => Config.return<'a> = "toBeCloseTo"
 
     @send
     external toBeGreaterThan: (expected, t) => Config.return<'a> = "toBeGreaterThan"


### PR DESCRIPTION
Spelling/typographical correction for the float match external.

https://vitest.dev/api/expect.html#tobecloseto