### PR TITLE
Vite 5.0 is out!

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "peerDependencies": {
     "rescript": "^10.1.0 || ^11.0.0-alpha.0",
-    "vite": "^2.0.0 || ^3.0.0 || ^4.0.0"
+    "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "dependencies": {
     "vitest": "^0.31.0"


### PR DESCRIPTION
> See blog post [Vite 5.0 is out!](https://vitejs.dev/blog/announcing-vite5.html) for more details.

To address peer dependency error/warning after upgrading vite to 5.0. For example:

```sh
[10:05:22.559] Installing dependencies...
[10:05:24.887] npm ERR! code ERESOLVE
[10:05:24.890] npm ERR! ERESOLVE could not resolve
[10:05:24.891] npm ERR! 
[10:05:24.891] npm ERR! While resolving: rescript-vitest@1.2.0
[10:05:24.891] npm ERR! Found: vite@5.0.2
[10:05:24.891] npm ERR! node_modules/vite
[10:05:24.892] npm ERR!   dev vite@"^5.0.2" from the root project
[10:05:24.892] npm ERR!   peer vite@"^4.2.0 || ^5.0.0" from @vitejs/plugin-react@4.2.0
[10:05:24.892] npm ERR!   node_modules/@vitejs/plugin-react
[10:05:24.892] npm ERR!     dev @vitejs/plugin-react@"^4.2.0" from the root project
[10:05:24.892] npm ERR!   3 more (vite-node, vitest, @jihchi/vite-plugin-rescript)
[10:05:24.893] npm ERR! 
[10:05:24.893] npm ERR! Could not resolve dependency:
[10:05:24.893] npm ERR! peer vite@"^2.0.0 || ^3.0.0 || ^4.0.0" from rescript-vitest@1.2.0
[10:05:24.893] npm ERR! node_modules/rescript-vitest
[10:05:24.894] npm ERR!   dev rescript-vitest@"^1.2.0" from the root project
[10:05:24.894] npm ERR! 
[10:05:24.894] npm ERR! Conflicting peer dependency: vite@4.5.0
[10:05:24.894] npm ERR! node_modules/vite
[10:05:24.894] npm ERR!   peer vite@"^2.0.0 || ^3.0.0 || ^4.0.0" from rescript-vitest@1.2.0
[10:05:24.894] npm ERR!   node_modules/rescript-vitest
[10:05:24.894] npm ERR!     dev rescript-vitest@"^1.2.0" from the root project
[10:05:24.894] npm ERR! 
[10:05:24.894] npm ERR! Fix the upstream dependency conflict, or retry
[10:05:24.894] npm ERR! this command with --force or --legacy-peer-deps
[10:05:24.895] npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
[10:05:24.895] npm ERR! 
[10:05:24.895] npm ERR! 
[10:05:24.895] npm ERR! For a full report see:
[10:05:24.895] npm ERR! /vercel/.npm/_logs/2023-11-25T08_05_23_178Z-eresolve-report.txt
[10:05:24.895] 
[10:05:24.895] npm ERR! A complete log of this run can be found in: /vercel/.npm/_logs/2023-11-25T08_05_23_178Z-debug-0.log
[10:05:24.907] Error: Command "npm install" exited with 1
[10:05:25.282] 
```

## Changes

- Add `vite@^5.0.0` as a peer dependency
