### PR TITLE
Compiles with ReScript v11

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 ReScript v10.1+ is required since v1.0.0. To use `Js.Promise2` and `async`/`await` for tests.
 
+ReScript v11 can be used with `"uncurried": false`
+
 ## Config
 
 Configure with plain `vite.config.js`.

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,5 +1,6 @@
 {
   "name": "rescript-vitest",
+  "uncurried": false,
   "namespace": false,
   "suffix": ".mjs",
   "sources": [

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "src/Vitest.res"
   ],
   "peerDependencies": {
-    "rescript": "^10.1.0 || ^11.0.0-alpha.0",
+    "rescript": "^10.1.0 || ^11.0.0",
     "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "dependencies": {
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@jihchi/vite-plugin-rescript": "^5.5.0",
-    "rescript": "^10.1.4",
+    "rescript": "^11.0.1",
     "vite": "^5.0.2"
   },
   "packageManager": "yarn@4.0.2"

--- a/src/Vitest.res
+++ b/src/Vitest.res
@@ -232,10 +232,10 @@ module Concurrent = {
   ) => unit = "concurrent"
 
   include MakeConcurrentRunner({
-    let describe = concurrent_describe->describe
-    let testAsync = concurrent_test->testAsync
-    let itAsync = concurrent_it->itAsync
-    let benchAsync = concurrent_bench->benchAsync
+    let describe = describe(concurrent_describe)
+    let testAsync = testAsync(concurrent_test)
+    let itAsync = itAsync(concurrent_it)
+    let benchAsync = benchAsync(concurrent_bench)
   })
 }
 
@@ -308,16 +308,16 @@ module Only = {
   ) => unit = "only"
 
   include MakeRunner({
-    let describe = only_describe->describe
+    let describe = describe(only_describe)
 
-    let test = only_test->test
-    let testAsync = only_test->testAsync
+    let test = test(only_test)
+    let testAsync = testAsync(only_test)
 
-    let it = only_it->it
-    let itAsync = only_it->itAsync
+    let it = it(only_it)
+    let itAsync = itAsync(only_it)
 
-    let bench = only_bench->bench
-    let benchAsync = only_bench->benchAsync
+    let bench = bench(only_bench)
+    let benchAsync = benchAsync(only_bench)
   })
 
   module Concurrent = {
@@ -373,10 +373,10 @@ module Only = {
     ) => unit = "concurrent"
 
     include MakeConcurrentRunner({
-      let describe = only_describe->concurrent_describe->describe
-      let testAsync = only_test->concurrent_test->testAsync
-      let itAsync = only_it->concurrent_it->itAsync
-      let benchAsync = only_bench->concurrent_bench->benchAsync
+      let describe = describe(only_describe->concurrent_describe)
+      let testAsync = testAsync(only_test->concurrent_test)
+      let itAsync = itAsync(only_it->concurrent_it)
+      let benchAsync = benchAsync(only_bench->concurrent_bench)
     })
   }
 }
@@ -450,16 +450,16 @@ module Skip = {
   ) => unit = "skip"
 
   include MakeRunner({
-    let describe = skip_describe->describe
+    let describe = describe(skip_describe)
 
-    let test = skip_test->test
-    let testAsync = skip_test->testAsync
+    let test = test(skip_test)
+    let testAsync = testAsync(skip_test)
 
-    let it = skip_it->it
-    let itAsync = skip_it->itAsync
+    let it = it(skip_it)
+    let itAsync = itAsync(skip_it)
 
-    let bench = skip_bench->bench
-    let benchAsync = skip_bench->benchAsync
+    let bench = bench(skip_bench)
+    let benchAsync = benchAsync(skip_bench)
   })
 
   module Concurrent = {
@@ -515,10 +515,10 @@ module Skip = {
     ) => unit = "concurrent"
 
     include MakeConcurrentRunner({
-      let describe = skip_describe->concurrent_describe->describe
-      let testAsync = skip_test->concurrent_test->testAsync
-      let itAsync = skip_it->concurrent_it->itAsync
-      let benchAsync = skip_bench->concurrent_bench->benchAsync
+      let describe = describe(skip_describe->concurrent_describe)
+      let testAsync = testAsync(skip_test->concurrent_test)
+      let itAsync = itAsync(skip_it->concurrent_it)
+      let benchAsync = benchAsync(skip_bench->concurrent_bench)
     })
   }
 }
@@ -609,33 +609,27 @@ module Each: EachType = {
     external testObj: (
       ~test: test,
       ~cases: array<'a>,
-      . ~name: string,
-      ~f: @uncurry 'a => unit,
-      ~timeout: Js.undefined<int>,
-    ) => unit = "each"
+    ) => (. ~name: string, ~f: @uncurry 'a => unit, ~timeout: Js.undefined<int>) => unit = "each"
 
     @send
     external test2: (
       ~test: test,
       ~cases: array<('a, 'b)>,
-      . ~name: string,
-      ~f: @uncurry ('a, 'b) => unit,
-      ~timeout: Js.undefined<int>,
-    ) => unit = "each"
+    ) => (. ~name: string, ~f: @uncurry ('a, 'b) => unit, ~timeout: Js.undefined<int>) => unit =
+      "each"
 
     @send
     external test3: (
       ~test: test,
       ~cases: array<('a, 'b, 'c)>,
-      . ~name: string,
-      ~f: @uncurry ('a, 'b, 'c) => unit,
-      ~timeout: Js.undefined<int>,
-    ) => unit = "each"
+    ) => (. ~name: string, ~f: @uncurry ('a, 'b, 'c) => unit, ~timeout: Js.undefined<int>) => unit =
+      "each"
 
     @send
     external test4: (
       ~test: test,
       ~cases: array<('a, 'b, 'c, 'd)>,
+    ) => (
       . ~name: string,
       ~f: @uncurry ('a, 'b, 'c, 'd) => unit,
       ~timeout: Js.undefined<int>,
@@ -645,6 +639,7 @@ module Each: EachType = {
     external test5: (
       ~test: test,
       ~cases: array<('a, 'b, 'c, 'd, 'e)>,
+    ) => (
       . ~name: string,
       ~f: @uncurry ('a, 'b, 'c, 'd, 'e) => unit,
       ~timeout: Js.undefined<int>,
@@ -654,15 +649,14 @@ module Each: EachType = {
     external testObjAsync: (
       ~test: test,
       ~cases: array<'a>,
-      . ~name: string,
-      ~f: @uncurry 'a => promise<unit>,
-      ~timeout: Js.undefined<int>,
-    ) => unit = "each"
+    ) => (. ~name: string, ~f: @uncurry 'a => promise<unit>, ~timeout: Js.undefined<int>) => unit =
+      "each"
 
     @send
     external test2Async: (
       ~test: test,
       ~cases: array<('a, 'b)>,
+    ) => (
       . ~name: string,
       ~f: @uncurry ('a, 'b) => promise<unit>,
       ~timeout: Js.undefined<int>,
@@ -672,6 +666,7 @@ module Each: EachType = {
     external test3Async: (
       ~test: test,
       ~cases: array<('a, 'b, 'c)>,
+    ) => (
       . ~name: string,
       ~f: @uncurry ('a, 'b, 'c) => promise<unit>,
       ~timeout: Js.undefined<int>,
@@ -681,6 +676,7 @@ module Each: EachType = {
     external test4Async: (
       ~test: test,
       ~cases: array<('a, 'b, 'c, 'd)>,
+    ) => (
       . ~name: string,
       ~f: @uncurry ('a, 'b, 'c, 'd) => promise<unit>,
       ~timeout: Js.undefined<int>,
@@ -690,6 +686,7 @@ module Each: EachType = {
     external test5Async: (
       ~test: test,
       ~cases: array<('a, 'b, 'c, 'd, 'e)>,
+    ) => (
       . ~name: string,
       ~f: @uncurry ('a, 'b, 'c, 'd, 'e) => promise<unit>,
       ~timeout: Js.undefined<int>,
@@ -699,33 +696,27 @@ module Each: EachType = {
     external describeObj: (
       ~describe: describe,
       ~cases: array<'a>,
-      . ~name: string,
-      ~f: @uncurry 'a => unit,
-      ~timeout: Js.undefined<int>,
-    ) => unit = "each"
+    ) => (. ~name: string, ~f: @uncurry 'a => unit, ~timeout: Js.undefined<int>) => unit = "each"
 
     @send
     external describe2: (
       ~describe: describe,
       ~cases: array<('a, 'b)>,
-      . ~name: string,
-      ~f: @uncurry ('a, 'b) => unit,
-      ~timeout: Js.undefined<int>,
-    ) => unit = "each"
+    ) => (. ~name: string, ~f: @uncurry ('a, 'b) => unit, ~timeout: Js.undefined<int>) => unit =
+      "each"
 
     @send
     external describe3: (
       ~describe: describe,
       ~cases: array<('a, 'b, 'c)>,
-      . ~name: string,
-      ~f: @uncurry ('a, 'b, 'c) => unit,
-      ~timeout: Js.undefined<int>,
-    ) => unit = "each"
+    ) => (. ~name: string, ~f: @uncurry ('a, 'b, 'c) => unit, ~timeout: Js.undefined<int>) => unit =
+      "each"
 
     @send
     external describe4: (
       ~describe: describe,
       ~cases: array<('a, 'b, 'c, 'd)>,
+    ) => (
       . ~name: string,
       ~f: @uncurry ('a, 'b, 'c, 'd) => unit,
       ~timeout: Js.undefined<int>,
@@ -735,6 +726,7 @@ module Each: EachType = {
     external describe5: (
       ~describe: describe,
       ~cases: array<('a, 'b, 'c, 'd, 'e)>,
+    ) => (
       . ~name: string,
       ~f: @uncurry ('a, 'b, 'c, 'd, 'e) => unit,
       ~timeout: Js.undefined<int>,
@@ -744,15 +736,14 @@ module Each: EachType = {
     external describeObjAsync: (
       ~describe: describe,
       ~cases: array<'a>,
-      . ~name: string,
-      ~f: @uncurry 'a => promise<unit>,
-      ~timeout: Js.undefined<int>,
-    ) => unit = "each"
+    ) => (. ~name: string, ~f: @uncurry 'a => promise<unit>, ~timeout: Js.undefined<int>) => unit =
+      "each"
 
     @send
     external describe2Async: (
       ~describe: describe,
       ~cases: array<('a, 'b)>,
+    ) => (
       . ~name: string,
       ~f: @uncurry ('a, 'b) => promise<unit>,
       ~timeout: Js.undefined<int>,
@@ -762,6 +753,7 @@ module Each: EachType = {
     external describe3Async: (
       ~describe: describe,
       ~cases: array<('a, 'b, 'c)>,
+    ) => (
       . ~name: string,
       ~f: @uncurry ('a, 'b, 'c) => promise<unit>,
       ~timeout: Js.undefined<int>,
@@ -771,6 +763,7 @@ module Each: EachType = {
     external describe4Async: (
       ~describe: describe,
       ~cases: array<('a, 'b, 'c, 'd)>,
+    ) => (
       . ~name: string,
       ~f: @uncurry ('a, 'b, 'c, 'd) => promise<unit>,
       ~timeout: Js.undefined<int>,
@@ -780,6 +773,7 @@ module Each: EachType = {
     external describe5Async: (
       ~describe: describe,
       ~cases: array<('a, 'b, 'c, 'd, 'e)>,
+    ) => (
       . ~name: string,
       ~f: @uncurry ('a, 'b, 'c, 'd, 'e) => promise<unit>,
       ~timeout: Js.undefined<int>,

--- a/src/insource.res
+++ b/src/insource.res
@@ -1,6 +1,6 @@
 if Vitest.inSource {
   open Vitest
-  open Vitest.InSource
+  open! Vitest.InSource
 
   test("In-source testing", _ => {
     expect(1 + 2)->Expect.toBe(3)

--- a/tests/suite.test.res
+++ b/tests/suite.test.res
@@ -6,7 +6,7 @@ describe("suite name", () => {
     Assert.equal(Math.sqrt(4.0), 2.0)
   })
 
-  open Vitest.Expect
+  open! Vitest.Expect
 
   it("bar", _ => {
     expect(1 + 1)->eq(2)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1509,24 +1509,23 @@ __metadata:
   resolution: "rescript-vitest@workspace:."
   dependencies:
     "@jihchi/vite-plugin-rescript": "npm:^5.5.0"
-    rescript: "npm:^10.1.4"
+    rescript: "npm:^11.0.1"
     vite: "npm:^5.0.2"
     vitest: "npm:^0.34.6"
   peerDependencies:
-    rescript: ^10.1.0 || ^11.0.0-alpha.0
+    rescript: ^10.1.0 || ^11.0.0
     vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
   languageName: unknown
   linkType: soft
 
-"rescript@npm:^10.1.4":
-  version: 10.1.4
-  resolution: "rescript@npm:10.1.4"
+"rescript@npm:^11.0.1":
+  version: 11.0.1
+  resolution: "rescript@npm:11.0.1"
   bin:
     bsc: bsc
-    bsrefmt: bsrefmt
     bstracing: lib/bstracing
     rescript: rescript
-  checksum: 2549750314c865beed52f3fe828ca653386c784e053e640e011ef8165594757702abfe080f4ead5b0c95c3f577b1dd98a3df937e8e5256d69bc6bb13c8e31124
+  checksum: a37dc757a14c57a15fe75a12df52f3d564cc6ef5cacc8356fe70a7d4ab9692736c0fbb56456dff090d8b5b18935a09aed066c623e6764f4c76bed61187e611b7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This resolves #14 -- consumers can use ReScript v11 with or without uncurried mode.

The main change to get this working is to be more explicit with these curried external functions:

```diff
-      . ~name: string,
-      ~f: @uncurry 'a => unit,
-      ~timeout: Js.undefined<int>,
-    ) => unit = "each"
+    ) => (. ~name: string, ~f: @uncurry 'a => unit, ~timeout: Js.undefined<int>) => unit = "each"
```

This lets rescript-vitest compile on 10.1 and 11 regardless of uncurried mode.

The manual calls of instead of piping `only_describe->describe` for currying into the functors are for the ease of conversion to `describe(only_describe, ...)` which I have a different branch for. However I don't think you necessarily need to switch to uncurried for this right away, library consumers will just be prompted to use whatever function syntax their compiler settings are for.