### PR TITLE
Adds test.for, it.for, and describe.for bindings

### DIFF
--- a/src/Vitest.res
+++ b/src/Vitest.res
@@ -845,6 +845,117 @@ module Each: EachType = {
     )
 }
 
+module type ForType = {
+  let test: (array<'a>, string, ~timeout: int=?, ('a, testCtx) => unit) => unit
+  let testAsync: (array<'a>, string, ~timeout: int=?, ('a, testCtx) => promise<unit>) => unit
+
+  let it: (array<'a>, string, ~timeout: int=?, ('a, testCtx) => unit) => unit
+  let itAsync: (array<'a>, string, ~timeout: int=?, ('a, testCtx) => promise<unit>) => unit
+
+  let describe: (array<'a>, string, ~timeout: int=?, ('a, testCtx) => unit) => unit
+  let describeAsync: (array<'a>, string, ~timeout: int=?, ('a, testCtx) => promise<unit>) => unit
+}
+
+module For: ForType = {
+  module Ext = {
+    type test
+    type it
+    type describe
+
+    @module("vitest") @val
+    external test: test = "test"
+
+    @module("vitest") @val
+    external it: it = "it"
+
+    @module("vitest") @val
+    external describe: describe = "describe"
+
+    @send
+    external testObj: (
+      ~test: test,
+      ~cases: array<'a>,
+    ) => (~name: string, ~f: @uncurry ('a, testCtx) => unit, ~timeout: Js.undefined<int>) => unit =
+      "for"
+
+    @send
+    external testObjAsync: (
+      ~test: test,
+      ~cases: array<'a>,
+    ) => (
+      ~name: string,
+      ~f: @uncurry ('a, testCtx) => promise<unit>,
+      ~timeout: Js.undefined<int>,
+    ) => unit = "for"
+
+    @send
+    external itObj: (
+      ~it: it,
+      ~cases: array<'a>,
+    ) => (~name: string, ~f: @uncurry ('a, testCtx) => unit, ~timeout: Js.undefined<int>) => unit =
+      "for"
+
+    @send
+    external itObjAsync: (
+      ~it: it,
+      ~cases: array<'a>,
+    ) => (
+      ~name: string,
+      ~f: @uncurry ('a, testCtx) => promise<unit>,
+      ~timeout: Js.undefined<int>,
+    ) => unit = "for"
+
+    @send
+    external describeObj: (
+      ~describe: describe,
+      ~cases: array<'a>,
+    ) => (~name: string, ~f: @uncurry ('a, testCtx) => unit, ~timeout: Js.undefined<int>) => unit =
+      "for"
+
+    @send
+    external describeObjAsync: (
+      ~describe: describe,
+      ~cases: array<'a>,
+    ) => (
+      ~name: string,
+      ~f: @uncurry ('a, testCtx) => promise<unit>,
+      ~timeout: Js.undefined<int>,
+    ) => unit = "for"
+  }
+
+  @inline
+  let test = (cases, name, ~timeout=?, f) =>
+    Ext.testObj(~test=Ext.test, ~cases)(~name, ~f, ~timeout=timeout->Js.Undefined.fromOption)
+
+  @inline
+  let testAsync = (cases, name, ~timeout=?, f) =>
+    Ext.testObjAsync(~test=Ext.test, ~cases)(~name, ~f, ~timeout=timeout->Js.Undefined.fromOption)
+
+  @inline
+  let it = (cases, name, ~timeout=?, f) =>
+    Ext.itObj(~it=Ext.it, ~cases)(~name, ~f, ~timeout=timeout->Js.Undefined.fromOption)
+
+  @inline
+  let itAsync = (cases, name, ~timeout=?, f) =>
+    Ext.itObjAsync(~it=Ext.it, ~cases)(~name, ~f, ~timeout=timeout->Js.Undefined.fromOption)
+
+  @inline
+  let describe = (cases, name, ~timeout=?, f) =>
+    Ext.describeObj(~describe=Ext.describe, ~cases)(
+      ~name,
+      ~f,
+      ~timeout=timeout->Js.Undefined.fromOption,
+    )
+
+  @inline
+  let describeAsync = (cases, name, ~timeout=?, f) =>
+    Ext.describeObjAsync(~describe=Ext.describe, ~cases)(
+      ~name,
+      ~f,
+      ~timeout=timeout->Js.Undefined.fromOption,
+    )
+}
+
 module Todo = {
   type todo_describe
   type todo_test

--- a/tests/for.test.res
+++ b/tests/for.test.res
@@ -1,0 +1,107 @@
+open Vitest
+
+let sumObj = [{"a": 3, "b": 5, "sum": 8}, {"a": 6, "b": 2, "sum": 8}]
+let sum2 = [(1, "1"), (6, "6")]
+let sum3 = [(1, 3, "4"), (6, 3, "9")]
+let sum4 = [(1, 2, 8, "11"), (6, 3, 8, "17"), (5, 9, 2, "16")]
+let sum5 = [(1, 3, 8, 6, "18"), (6, 3, 2, 4, "15"), (5, 9, 2, 3, "19")]
+
+For.test(sumObj, "test: sum $a+$b=$sum", (i, t) => {
+  expect(t, i["a"] + i["b"])->Expect.toBe(i["sum"])
+  expect(t, i["a"] + i["b"] + 1)->Expect.not->Expect.toBe(i["sum"])
+})
+
+For.test(sum2, "test: %i=%s", ((a, b), t) => {
+  expect(t, a->Js.Int.toString)->Expect.toBe(b)
+  expect(t, (a + 1)->Js.Int.toString)->Expect.not->Expect.toBe(b)
+})
+
+For.test(sum3, "test: sum %i+%i=%s", ((a, b, sum), t) => {
+  expect(t, (a + b)->Js.Int.toString)->Expect.toBe(sum)
+  expect(t, (a + b + 1)->Js.Int.toString)->Expect.not->Expect.toBe(sum)
+})
+
+For.test(sum4, "test: sum %i+%i+%i=%s", ((a, b, c, sum), t) => {
+  expect(t, (a + b + c)->Js.Int.toString)->Expect.toBe(sum)
+  expect(t, (a + b + c + 1)->Js.Int.toString)->Expect.not->Expect.toBe(sum)
+})
+
+For.test(sum5, "test: sum %i+%i+%i+%i=%s", ((a, b, c, d, sum), t) => {
+  expect(t, (a + b + c + d)->Js.Int.toString)->Expect.toBe(sum)
+  expect(t, (a + b + c + d + 1)->Js.Int.toString)->Expect.not->Expect.toBe(sum)
+})
+
+For.testAsync(sumObj, "testAsync: sum $a+$b=$sum", async (i, t) => {
+  expect(t, i["a"] + i["b"])->Expect.toBe(i["sum"])
+  expect(t, i["a"] + i["b"] + 1)->Expect.not->Expect.toBe(i["sum"])
+})
+
+For.testAsync(sum2, "testAsync: %i=%s", async ((a, b), t) => {
+  expect(t, a->Js.Int.toString)->Expect.toBe(b)
+  expect(t, (a + 1)->Js.Int.toString)->Expect.not->Expect.toBe(b)
+})
+
+For.testAsync(sum3, "testAsync: sum %i+%i=%s", async ((a, b, sum), t) => {
+  expect(t, (a + b)->Js.Int.toString)->Expect.toBe(sum)
+  expect(t, (a + b + 1)->Js.Int.toString)->Expect.not->Expect.toBe(sum)
+})
+
+For.testAsync(sum4, "testAsync: sum %i+%i+%i=%s", async ((a, b, c, sum), t) => {
+  expect(t, (a + b + c)->Js.Int.toString)->Expect.toBe(sum)
+  expect(t, (a + b + c + 1)->Js.Int.toString)->Expect.not->Expect.toBe(sum)
+})
+
+For.testAsync(sum5, "testAsync: sum %i+%i+%i+%i=%s", async ((a, b, c, d, sum), t) => {
+  expect(t, (a + b + c + d)->Js.Int.toString)->Expect.toBe(sum)
+  expect(t, (a + b + c + d + 1)->Js.Int.toString)->Expect.not->Expect.toBe(sum)
+})
+
+For.it(sumObj, "it: sum $a+$b=$sum", (i, t) => {
+  expect(t, i["a"] + i["b"])->Expect.toBe(i["sum"])
+  expect(t, i["a"] + i["b"] + 1)->Expect.not->Expect.toBe(i["sum"])
+})
+
+For.it(sum2, "it: %i=%s", ((a, b), t) => {
+  expect(t, a->Js.Int.toString)->Expect.toBe(b)
+  expect(t, (a + 1)->Js.Int.toString)->Expect.not->Expect.toBe(b)
+})
+
+For.it(sum3, "it: sum %i+%i=%s", ((a, b, sum), t) => {
+  expect(t, (a + b)->Js.Int.toString)->Expect.toBe(sum)
+  expect(t, (a + b + 1)->Js.Int.toString)->Expect.not->Expect.toBe(sum)
+})
+
+For.it(sum4, "it: sum %i+%i+%i=%s", ((a, b, c, sum), t) => {
+  expect(t, (a + b + c)->Js.Int.toString)->Expect.toBe(sum)
+  expect(t, (a + b + c + 1)->Js.Int.toString)->Expect.not->Expect.toBe(sum)
+})
+
+For.it(sum5, "it: sum %i+%i+%i+%i=%s", ((a, b, c, d, sum), t) => {
+  expect(t, (a + b + c + d)->Js.Int.toString)->Expect.toBe(sum)
+  expect(t, (a + b + c + d + 1)->Js.Int.toString)->Expect.not->Expect.toBe(sum)
+})
+
+For.itAsync(sumObj, "itAsync: sum $a+$b=$sum", async (i, t) => {
+  expect(t, i["a"] + i["b"])->Expect.toBe(i["sum"])
+  expect(t, i["a"] + i["b"] + 1)->Expect.not->Expect.toBe(i["sum"])
+})
+
+For.itAsync(sum2, "itAsync: %i=%s", async ((a, b), t) => {
+  expect(t, a->Js.Int.toString)->Expect.toBe(b)
+  expect(t, (a + 1)->Js.Int.toString)->Expect.not->Expect.toBe(b)
+})
+
+For.itAsync(sum3, "itAsync: sum %i+%i=%s", async ((a, b, sum), t) => {
+  expect(t, (a + b)->Js.Int.toString)->Expect.toBe(sum)
+  expect(t, (a + b + 1)->Js.Int.toString)->Expect.not->Expect.toBe(sum)
+})
+
+For.itAsync(sum4, "itAsync: sum %i+%i+%i=%s", async ((a, b, c, sum), t) => {
+  expect(t, (a + b + c)->Js.Int.toString)->Expect.toBe(sum)
+  expect(t, (a + b + c + 1)->Js.Int.toString)->Expect.not->Expect.toBe(sum)
+})
+
+For.itAsync(sum5, "itAsync: sum %i+%i+%i+%i=%s", async ((a, b, c, d, sum), t) => {
+  expect(t, (a + b + c + d)->Js.Int.toString)->Expect.toBe(sum)
+  expect(t, (a + b + c + d + 1)->Js.Int.toString)->Expect.not->Expect.toBe(sum)
+})


### PR DESCRIPTION
These have the test context passed as an argument, and preserves the
array's tuple to be passed in as the first argument. This removes the
need for the -N suffix bindings and allows use of the non-BuiltIn
bindings